### PR TITLE
fix: catch error that 'statuses' might throw

### DIFF
--- a/src/adapters/request.ts
+++ b/src/adapters/request.ts
@@ -24,6 +24,12 @@ export const requestAdapter = <T = UnData, D = UnData>(config: UnConfig<T, D>) =
     task = uni.request({
       ...requestConfig,
       success: (res) => {
+        let statusText;
+        try {
+          statusText = statuses(res?.statusCode)?.toString();
+        } catch (error) {
+          statusText = (error as Error).toString();
+        }
         response = {
           ...response,
           // @ts-expect-error
@@ -34,7 +40,7 @@ export const requestAdapter = <T = UnData, D = UnData>(config: UnConfig<T, D>) =
           // @ts-expect-error
           profile: res?.profile,
           status: res?.statusCode,
-          statusText: statuses(res?.statusCode)?.toString(),
+          statusText,
           // @ts-expect-error
           headers: res?.header ?? res?.headers,
           config,


### PR DESCRIPTION
<!--

DO NOT INGORE THE TEMPLATE!
请不要忽视这个模板！

Thank you for contributing!
感谢你的贡献！

Before submitting the PR, please make sure you do the following:
在提交PR之前，请确保你做到以下几点：

- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.
- 检查是否已经有一个以同样方式解决该问题的 PR，以避免重复创建。
- 在这个 PR 中描述 **PR 所要解决的问题**，或者引用它所解决的问题（例如 `fixes #123`）。
- 理想情况下，提交没有这个 PR 的情况下失败但在有 PR 的情况下通过的相关测试。

-->

### Description 描述

当Response HTTP Code为“statuses”未列出的值时，“statuses()”的调用处会抛出异常，无法正常返回响应内容。
所以我在此简单处理了一下这个部分的逻辑，使用catch捕捉可能由“statuses()”的调用抛出的异常。

### Linked Issues 关联的 Issues


### Additional context 额外上下文

<!--

e.g. is there anything you'd like reviewers to focus on?
例如，有什么东西是你希望审查人关注的？

-->
