### PR TITLE
fix: merge adapter config in request

### DIFF
--- a/src/core/Un.ts
+++ b/src/core/Un.ts
@@ -24,7 +24,9 @@ export class Un<T = UnData, D = UnData> {
 
   request(configOrUrl: string | UnConfig<T, D>, config?: UnConfig<T, D>) {
     const _config =
-      typeof configOrUrl === 'string' ? { ...config, url: configOrUrl } : { ...configOrUrl };
+      typeof configOrUrl === 'string'
+        ? { ...config, url: configOrUrl }
+        : { ...configOrUrl, ...config };
 
     const mergedConfig = mergeConfig(this.defaults, _config);
 


### PR DESCRIPTION
<!--

DO NOT INGORE THE TEMPLATE!
请不要忽视这个模板！

Thank you for contributing!
感谢你的贡献！

Before submitting the PR, please make sure you do the following:
在提交PR之前，请确保你做到以下几点：

- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.
- 检查是否已经有一个以同样方式解决该问题的 PR，以避免重复创建。
- 在这个 PR 中描述 **PR 所要解决的问题**，或者引用它所解决的问题（例如 `fixes #123`）。
- 理想情况下，提交没有这个 PR 的情况下失败但在有 PR 的情况下通过的相关测试。

-->

### Description 描述

当使用`upload`上传文件时，只传递`config`参数，且`config`中不提供`adapter`配置时，会使用`request adapter`，而不是`upload adapter`。

`upload`同理。

```js
Un.upload({
    url: '/images',
    filePath,
    name: 'file',
    // 不设置"adapter"的值为"upload"，"adapter"将会是默认值"request"
    // adapter: 'upload', 
  })
```
此PR修复了上面提到的问题。

<!--

Please insert your description here and provide especially info about the "what" this PR is solving
请在此插入你的描述，并提供有关该 PR 所解决的 **问题** 的信息。

-->

### Linked Issues 关联的 Issues


### Additional context 额外上下文

<!--

e.g. is there anything you'd like reviewers to focus on?
例如，有什么东西是你希望审查人关注的？

-->
