### PR TITLE
fix(uni-network): when the request fails, the interceptor cannot get the request configuration

### DIFF
--- a/packages/core/src/adapters/request.ts
+++ b/packages/core/src/adapters/request.ts
@@ -54,6 +54,7 @@ export const requestAdapter = <T = UnData, D = UnData>(
       fail: (err) => {
         response = {
           ...response,
+          config,
           // @ts-expect-error no types
           errMsg: err?.errMsg ?? err?.errmsg ?? err?.msg ?? err?.message,
           // @ts-expect-error no types

--- a/packages/core/src/adapters/upload.ts
+++ b/packages/core/src/adapters/upload.ts
@@ -57,6 +57,7 @@ export const uploadAdapter = <T = UnData, D = UnData>(config: UnConfig<T, D>) =>
       fail: (err) => {
         response = {
           ...response,
+          config,
           // @ts-expect-error no types
           errMsg: err?.errMsg ?? err?.errmsg ?? err?.msg ?? err?.message,
           // @ts-expect-error no types


### PR DESCRIPTION
请求失败时，全局的失败拦截器无法获得请求配置。

### Description 描述

本次合并将会使全局的失败拦截器获得完整的请求配置**config**。

### Linked Issues 关联的 Issues

### Additional context 额外上下文

UnError类型定义中也提到了config参数，现状是根本无法获得此参数。

详见：https://github.com/uni-helper/uni-network/blob/main/packages/core/src/core/UnError.ts

<!--

e.g. is there anything you'd like reviewers to focus on?
例如，有什么东西是你希望审查人关注的？

-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error responses for both request and upload functionalities by including the configuration details in the error response, improving context for debugging and error handling.

- **Bug Fixes**
	- Maintained existing error handling logic and control flow for cancellations, ensuring consistent behavior during failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->