### PR TITLE
fix: interface UnCancel(#57)

### DIFF
--- a/packages/core/src/core/UnCancelToken.test.ts
+++ b/packages/core/src/core/UnCancelToken.test.ts
@@ -31,6 +31,7 @@ describe("core:UnCancelToken", () => {
       cancel("Operation has been canceled.");
       expect(token.reason).toEqual(expect.any(UnCanceledError));
       expect(token.reason?.message).toBe("Operation has been canceled.");
+      expect(token.reason?.isUnCanceledError).toBe(true);
     });
 
     it("returns undefined if cancellation has not been requested", () => {

--- a/packages/core/src/core/UnCancelToken.ts
+++ b/packages/core/src/core/UnCancelToken.ts
@@ -3,6 +3,7 @@ import { UnCanceledError } from "./UnCanceledError";
 
 export interface UnCancel {
   message?: string;
+  isUnCanceledError: true;
 }
 
 export interface UnCancelStatic {

--- a/packages/core/src/core/UnCanceledError.ts
+++ b/packages/core/src/core/UnCanceledError.ts
@@ -2,7 +2,7 @@ import type { UnConfig, UnData, UnTask } from "../types";
 import { UnError } from "./UnError";
 
 class UnCanceledError<T = UnData, D = UnData> extends UnError<T, D> {
-  isUnCanceledError = true;
+  isUnCanceledError: true = true;
 
   constructor(message?: string, config?: UnConfig<T, D>, task?: UnTask) {
     super(message ?? "canceled");


### PR DESCRIPTION
<!--

DO NOT INGORE THE TEMPLATE!
请不要忽视这个模板！

Before submitting the PR, please make sure you do the following:
在提交 PR 之前，请确保你做到以下几点：

- Read the [Contributing Guide](https://github.com/antfu/contribute) and [Notes from a tired maintainer](https://github.com/pi0/tired-maintainer).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.
- 阅读 [贡献指南](https://github.com/antfu/contribute) 和 [一位疲惫的维护者的笔记](https://github.com/ModyQyW/tired-maintainer)。
- 检查是否已经有一个以同样方式解决该问题的 PR，以避免重复创建。
- 在这个 PR 中描述 **PR 所要解决的问题**，或者引用它所解决的问题（例如 `fixes #123`）。
- 理想情况下，提交没有这个 PR 的情况下失败但在有 PR 的情况下通过的相关测试。

-->

### Description 描述
UnCancel的类型定义仅有message属性，但isUnCancel中使用isUnCanceledError判断，导致类型无法正确约束。
<!--

Please insert your description here and provide especially info about the "what" this PR is solving
请在此插入你的描述，并提供有关该 PR 所解决的 **问题** 的信息。

-->

### Linked Issues 关联的 Issues
#57 
### Additional context 额外上下文

<!--

e.g. is there anything you'd like reviewers to focus on?
例如，有什么东西是你希望审查人关注的？

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new property `isUnCanceledError` in the `UnCancel` interface to indicate an uncanceled error.
  
- **Bug Fixes**
	- Enhanced test coverage for the `UnCancelToken` class by adding an assertion to validate the `reason` property.

- **Documentation**
	- Clarified the type of the `isUnCanceledError` property in the `UnCanceledError` class.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->