### PR TITLE
docs: update `name` option description

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,7 +449,7 @@ const instance = un.create({
   // 文件路径，files 和 filePath 必填一个
   //
   // download 使用
-  // 文件下载后存储的本地路径，支持相对路径与绝对路径
+  // 文件下载后存储的本地路径
   filePath: '/fake/path',
 
   // upload 使用

--- a/README.md
+++ b/README.md
@@ -449,12 +449,12 @@ const instance = un.create({
   // 文件路径，files 和 filePath 必填一个
   //
   // download 使用
-  // 文件下载后存储的本地路径
+  // 文件下载后存储的本地路径，支持相对路径与绝对路径
   filePath: '/fake/path',
 
   // upload 使用
-  // 文件名称
-  name: 'fake-file.png',
+  // 文件对应的 key , 开发者在服务器端通过这个 key 可以获取到文件二进制内容
+  name: 'file',
 
   // upload 使用
   // 一个对象，会作为 HTTP 请求中其它额外的 form data

--- a/docs/api/request-config.md
+++ b/docs/api/request-config.md
@@ -178,7 +178,7 @@
   // 文件路径，files 和 filePath 必填一个
   //
   // download 使用
-  // 文件下载后存储的本地路径，支持相对路径与绝对路径
+  // 文件下载后存储的本地路径
   filePath: "/fake/path",
 
   // upload 使用

--- a/docs/api/request-config.md
+++ b/docs/api/request-config.md
@@ -178,12 +178,12 @@
   // 文件路径，files 和 filePath 必填一个
   //
   // download 使用
-  // 文件下载后存储的本地路径
+  // 文件下载后存储的本地路径，支持相对路径与绝对路径
   filePath: "/fake/path",
 
   // upload 使用
-  // 文件名称
-  name: "fake-file.png",
+  // 文件对应的 key , 开发者在服务器端通过这个 key 可以获取到文件二进制内容
+  name: "file",
 
   // upload 使用
   // 一个对象，会作为 HTTP 请求中其它额外的 form data

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -242,13 +242,13 @@ export interface UnConfig<T = UnData, D = UnData> {
    *
    * Download 使用
    *
-   * 文件下载后存储的本地路径
+   * 文件下载后存储的本地路径，支持相对路径与绝对路径
    */
   filePath?: string;
   /**
    * Upload 使用
    *
-   * 文件名称
+   * 文件对应的 key , 开发者在服务器端通过这个 key 可以获取到文件二进制内容
    */
   name?: string;
   /**

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -242,7 +242,7 @@ export interface UnConfig<T = UnData, D = UnData> {
    *
    * Download 使用
    *
-   * 文件下载后存储的本地路径，支持相对路径与绝对路径
+   * 文件下载后存储的本地路径
    */
   filePath?: string;
   /**


### PR DESCRIPTION
### Description 描述

目前文档和代码中对 UnConfig.name 的注释有明显的歧义。很容易误导没看过 uni.uploadFile 文档的人。



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified that the `filePath` option supports both relative and absolute paths in upload/download configuration.
  - Updated the description of the `name` option to specify it is a file key used by the server to access file content, not a file name.
  - Improved example values and comments for better understanding of configuration options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->